### PR TITLE
Add Motion predictor

### DIFF
--- a/model.py
+++ b/model.py
@@ -5,7 +5,7 @@ F = nn.functional
 
 
 class Conv3D(nn.Module):
-    """General 3D Convolution block."""
+    """General 3D Convolution block, with 3x3x3 kernel."""
 
     def __init__(self,
                  c_in: int,
@@ -48,7 +48,51 @@ class Conv3D(nn.Module):
         return self.layers(x)
 
 
-class ConvResBlock(nn.Module):
+class Conv2D(nn.Module):
+    """General 3D Convolution block, with 3x3 kernel."""
+
+    def __init__(self,
+                 c_in: int,
+                 c_out: int,
+                 stride: Union[int, Tuple[int, int]],
+                 use_bn: bool = True,
+                 use_up: bool = False,
+                 lrelu_eps: float = 0.2,
+                 ):
+        """
+
+        Args:
+            c_in: Number of input channels.
+            c_out: Number of output channels.
+            stride: Convolution stride.
+            use_bn: Whether to use batch normalization. (nn.BatchNorm3d)
+            use_up: Whether to use trilinear upsampling (nn.Upsample)
+            lrelu_eps: nn.LeakyRelu slope parameter.
+                WARN(ycho): defaults to 0.2 (according to the paper),
+                but beware that the author's implementation seems to use 1e-2.
+        """
+        super().__init__()
+
+        layers: List[nn.Module] = []
+        layers.append(nn.Conv2d(
+            c_in, c_out, (3, 3),
+            stride, padding=1, bias=False))
+        if use_bn:
+            layers.append(nn.BatchNorm2d(c_out))
+        layers.append(nn.LeakyReLU(lrelu_eps, inplace=True))
+        if use_up:
+            layers.append(
+                nn.Upsample(
+                    scale_factor=2,
+                    mode='bilinear',
+                    align_corners=True))
+        self.layers = nn.Sequential(*layers)
+
+    def forward(self, x: th.Tensor) -> th.Tensor:
+        return self.layers(x)
+
+
+class Conv3DResBlock(nn.Module):
     """Convolutional residual block, x'=x+f(x)."""
 
     def __init__(self, c_in: int, c_out: int,
@@ -100,8 +144,8 @@ class SceneEncoder(nn.Module):
                 enc_channels[1:])):
             stride = (2 if (i in (0, 1, 5, 9)) else 1)
             enc_layers.append(Conv3D(c_in, c_out, stride))
-        enc_layers.append(ConvResBlock(128, 128))
-        enc_layers.append(ConvResBlock(128, 128))
+        enc_layers.append(Conv3DResBlock(128, 128))
+        enc_layers.append(Conv3DResBlock(128, 128))
         split = enc_layers[:1], enc_layers[1:5], enc_layers[5:9], enc_layers[9:]
         self.enc = [nn.Sequential(*l) for l in split]
 
@@ -139,63 +183,139 @@ class SceneEncoder(nn.Module):
         return x
 
 
+class MotionProjector(nn.Module):
+
+    def __init__(self):
+        self.grids: th.Tensor = None
+
+    def forward(self, inputs: Dict[str, th.Tensor]) -> th.Tensor:
+        mask = inputs['mask']
+
+        # Lots of shape manipulation and normalization w.r.t `mask`
+        mask_object = torch.narrow(mask, 1, 0, K - 1)
+        sum_mask = torch.sum(mask_object, dim=(2, 3, 4))
+        heatmap = torch.unsqueeze(mask_object, dim=2) * self.grids.to(device)
+        pivot_vec = torch.sum(heatmap, dim=(
+            3, 4, 5)) / torch.unsqueeze(sum_mask, dim=2)
+
+        # Concatenate the background dimensions.
+        # [Important] The last one is the background!
+        trans_vec = torch.cat([trans_vec, self.zero_vec.expand(
+            B, -1, -1).to(device)], dim=1).unsqueeze(-1)
+        rot_mat = torch.cat(
+            [rot_mat, self.eye_mat.expand(B, 1, -1, -1).to(device)],
+            dim=1)
+        pivot_vec = torch.cat([pivot_vec, self.zero_vec.expand(
+            B, -1, -1).to(device)], dim=1).unsqueeze(-1)
+
+        grids_flat = self.grids_flat.to(device)
+        grids_after_flat = rot_mat @ (
+            grids_flat - pivot_vec) + pivot_vec + trans_vec
+        motion = (grids_after_flat - grids_flat).view([B, K, 3, S1, S2, S3])
+
+        motion = torch.sum(motion * torch.unsqueeze(mask, 2), 1)
+
+
 class MotionPredictor(nn.Module):
     """DSR-Net Motion Predictor.
 
     Predicts scene flow from scene representation and action embeddings.
+    Assumes motion_type \\in SE(3), which results in a combination of:
+    * mask_decoder = MaskDecoder(K)
+    * transform_decoder = TransformDecoder(se3euler, K-1)
+    * se3 = SE3(se3euler)
+
+    and the output looks like:
+    mask_feature = SceneEncoder(...)
+
+
+    ...
+    logit, mask = mask_decoder(mask_feature)
+
+    transform_param = transform_decoder(mask_feature, input_action)
+    trans_vec, rot_mat = se3(transform_param)
     """
 
     def __init__(self, use_action: bool):
         super().__init__()
         # NOTE(ycho): `use_action` is only `False`
         # while we don't have ActionEmbedding() implemented.
-        self.use_action:bool = use_action
-        self.num_objects:int = 5
-        self.num_params:int = 6
+        self.use_action: bool = use_action
+        self.num_objects: int = 5
+        self.num_params: int = 6
 
-        feat_layers = []
-        channels: Tuple[int, ...] = (
-                8 + (8 if self.use_action else 0),
-                8 + (8 if self.use_action else 0),
-                16 + (16 if self.use_action else 0),
-                32, 32, 32, 64, 128, 128)
-        for i, (c_in, c_out) in enumerate(zip(channels[:-1], channels[1:])):
-            stride = (2 if i in (0,1,2,6,7) else 1)
-            feat_layers.append(Conv3D(c_in,c_out,stride))
-        split = feat_layers[:1], feat_layers[1:2], feat_layers[2:3], feat_layers[3:]
-        self.feat_layers = [nn.Sequential(*l) for l in split]
+        self.conv3d0 = Conv3D(16, 8, 2)
+        self.conv3d1 = Conv3D(16, 16, 2)
+        self.conv3d2 = Conv3D(32, 32, 2)
 
-        self.project = nn.Conv3d(128, 128, (4,4,2))
+        self.conv3d3 = Conv3D(32, 16, 1, use_up=True)
+        self.conv3d4 = Conv3D(16, 8, 1, use_up=True)
+        self.conv3d5 = Conv3D(8, 8, 1, use_up=True)
+        self.conv3d6 = nn.Conv3d(8, 3, kernel_size=3, padding=1)
 
-        # nn.Conv3d(
+        self.project = nn.Conv3d(128, 128, (4, 4, 2))
 
-        # (1) input of first three are concatenated with
-        # original action and two action embeddings <<?
-        # 2D tensor is repeated in the last channel to concatenate
-        # with 3d tensor.
+        # 8, 64, 64, 64, 64 (,8)
+        act1_channels = (8, 64, 64, 64, 64)
+        act1_layers = []
+        for i, (c_in, c_out) in enumerate(act1_channels[:-1],
+                                          act1_channels[1:]):
+            stride = (2 if i == 0 else 1)
+            act1_layers.append(Conv2D(c_in, c_out, stride))
+        self.action1 = nn.Sequential(*act1_layers)
+        self.action1e = Conv2D(64, 8)
+
+        # 64, 128, 128, 128, 128 (,16)
+        act2_channels = (64, 128, 128, 128, 128)
+        act2_layers = []
+        for i, (c_in, c_out) in enumerate(act2_channels[:-1],
+                                          act2_channels[1:]):
+            stride = (2 if i == 0 else 1)
+            act2_layers.append(Conv2D(c_in, c_out, stride))
+        self.action2 = nn.Sequential(*act2_layers)
+        self.action2e = Conv2D(128, 16)
 
     def forward(self, inputs: Dict[str, th.Tensor]) -> th.Tensor:
-        if self.use_action:
-            raise NotImplementedError('')
+        if not self.use_action:
+            action = th.zeros_like(x, size=(batch_size, 8, 128, 128))
+        else:
+            action = inputs['action']
 
-        # [... action ...]
-        # x = unsqueeze_and_concat(x, action)
-        x = self.feat_layers[0](x)
+        # Action features at each dimensions
+        action0 = action
+        action1 = self.action1(action0)
+        action2 = self.action2(action1)
 
-        # [... action ...]
-        # unsqueeze and concat ...
-        x = self.feat_layers[1](x)
+        # Repeat action embeddings across +z dim.
+        action0e = th.unsqueeze(action0e, -1)
+        action0e = action0e.expand([-1, -1, -1, -1, 48])
+        action1e = th.unsqueeze(self.action1e(action1e), -1)
+        action1e = action1e.expand([-1, -1, -1, -1, 24])
+        action2e = th.unsqueeze(self.actino2e(action2e), -1)
+        action2e = action2e.expand([-1, -1, -1, -1, 12])
 
-        # [... action ...]
-        # unsqueeze and concat ...
-        x = self.feat_layers[2](x)
+        # Mask Features
+        x = inputs['feature']
 
-        # conv20 ~ conv50
-        x = self.feat_layers[3](x)
+        x = th.cat([x, action0], dim=1)
+        x = self.conv3d0(x)
+        dx0 = x # residual output
 
-        x = self.project(x) # -> should be Bx128x1x1x1
-        x = x.squeeze(dim=(2,3,4)) # Bx128
-        x = self.transform_mlp(x) # Bx(NxP)
-        x = x.reshape(-1, self.num_objects, self.num_params) # BxNxP
+        x = th.cat([x, action1], dim=1)
+        x = self.conv3d1(x)
+        dx1 = x # residual output
+
+        x = th.cat([x, action2], dim=1)
+        x = self.conv3d2(x)
+
+        x = self.conv3d3(x)
+        x = self.conv3d4(x + dx1)
+        x = self.conv3d5(x + dx0)
+        x = self.conv3d6(x) # at this point, we have `motion_pred`
+
+        x = self.project(x)  # -> should be Bx128x1x1x1
+        x = x.squeeze(dim=(2, 3, 4))  # Bx128
+        x = self.transform_mlp(x)  # Bx(NxP)
+        x = x.reshape(-1, self.num_objects, self.num_params)  # BxNxP
 
         # NOTE(ycho): currently editing here

--- a/model.py
+++ b/model.py
@@ -360,7 +360,7 @@ class MotionPredictor(nn.Module):
         # NOTE(ycho): last "object" is reserved for background.
         # WARN(ycho): 5x512 in the paper, 4x512 hidden layers in the author's
         # code.
-        mlp_channels = (128, 512, 512, 512, 512, 512,
+        mlp_channels = (128, 512, 512, 512, 512,
                         self.num_params * (self.num_objects - 1))
         mlp_layers = []
         for i, (c_in, c_out) in epairwise(mlp_channels):

--- a/model.py
+++ b/model.py
@@ -282,6 +282,10 @@ class SO3(nn.Module):
         cx, cy, cz = [c[..., i] for i in range(3)]
         sx, sy, sz = [s[..., i] for i in range(3)]
 
+        # NOTE(ycho):
+        # Represents Rz@Ry@Rx matrix,
+        # Which is equivalent to:
+        # rotate_yaw(rotate_pitch(rotate_roll(point))).
         r = th.stack([
             cy * cz,
             (sx * sy * cz) - (cx * sz),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pycuda==2019.1.2
 numba==0.50.0
 numpy>=1.22
 scikit-image==0.16.2
+einops>=0.4.1

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,7 +6,7 @@ sys.path.append('../')
 import unittest
 
 import torch as th
-from model import SceneEncoder
+from model import SceneEncoder, MotionPredictor
 
 
 class TestSceneEncoder(unittest.TestCase):
@@ -27,6 +27,41 @@ class TestSceneEncoder(unittest.TestCase):
 
         # NOTE(ycho): shape-only test
         assert(state.shape == (batch_size, 8, 128, 128, 48))
+
+    def test_motion_predictor(self):
+        rng_state = th.get_rng_state()
+        try:
+            seed: int = 0
+            batch_size: int = 1
+            use_action: bool = True
+            num_objects: int = 5
+            num_params: int = 6
+            device: th.device = th.device('cpu')
+
+            th.manual_seed(seed)
+
+            motion_predictor = MotionPredictor(
+                use_action, num_objects, num_params).to(
+                device=device)
+
+            dummy = dict(
+                clf=th.randn(
+                    size=(batch_size, num_objects, 128, 128, 48),
+                    dtype=th.float32).to(device=device),
+                action=th.zeros(
+                    size=(batch_size, 8, 128, 128),
+                    dtype=th.float32).to(device=device),
+                feature=th.zeros(
+                    size=(batch_size, 8, 128, 128, 48),
+                    dtype=th.float32).to(device=device))
+            motion = motion_predictor(dummy)
+            # since clf is randn(), shouldn't really
+            # result in NaN...
+            assert((~th.isnan(motion)).all())
+            # NOTE(ycho): shape-only test
+            assert(motion.shape == (batch_size, 3, 128, 128, 48))
+        finally:
+            th.set_rng_state(rng_state)
 
 
 if __name__ == '__main__':

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -9,7 +9,7 @@ import torch as th
 from model import SceneEncoder
 
 
-class TestSceneEncoder(unittest.TestCase):
+class TestOps(unittest.TestCase):
     def test_narrow(self):
         seed: int = 0
         num_iter: int = 128

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import sys
+# FIXME(ycho): needed?
+sys.path.append('../')
+import unittest
+
+import torch as th
+from model import SceneEncoder
+
+
+class TestSceneEncoder(unittest.TestCase):
+    def test_narrow(self):
+        seed: int = 0
+        num_iter: int = 128
+
+        rng_state = th.get_rng_state()
+        try:
+            th.manual_seed(seed)
+            for _ in range(num_iter):
+                rank = th.randint(1, 9, ())
+                shape = th.randint(1, 8, (rank,))
+                dim = int(th.randint(0, rank, ()))
+                x = th.randn(size=tuple(int(x) for x in shape))
+
+                start = int(th.randint(0, shape[dim], ()))
+                length = int(th.randint(0, shape[dim] - start, ()))
+                x1 = th.narrow(x, dim, start, length)
+
+                I = [slice(None) for _ in range(rank)]
+                I[dim] = slice(start, start + length)
+                x2 = x[I]
+                assert(th.isclose(x1, x2).all())
+        finally:
+            th.set_rng_state(rng_state)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Add `MotionPredictor` module to `model.py`.
Re-written from on the paper, rather than the author's implementation.
Compared to the author's implementation,
some implementation choices are hard-coded according to defaults. For instance,
* use of euler-angle SO(3) parameterization)
* use of `TransformerDecoder()` type of motion decoder.

## Sanity Check

```bash
$ python3 -m pytest
========================================================= test session starts =========================================================
platform linux -- Python 3.8.0, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/jamiecho/Repos/Ravel/KAIST-CLASS/cs492/cs492-dsrnet
collected 3 items                                                                                                                     

test/test_model.py ..                                                                                                           [ 66%]
test/test_ops.py .                                                                                                              [100%]

========================================================== 3 passed in 0.64s ==========================================================
```

## Changelog
* add `Conv2D` module
* rename `ConvResBlock -> Conv3DResBlock`
* add `MotionProjector` module for constructing dense motion-vector field
* add non-parametric euler-angle `SO3` module
* add `MotionPredictor` module
* add `einops` to `requirements.txt`
* add `test_motion_predictor` for basic sanity check on shapes.
* add `test_ops.py` for testing outputs of some pytorch ops