### PR TITLE
Add training pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ numpy>=1.22
 scikit-image==0.16.2
 h5py==3.6.0
 einops>=0.4.1
+tqdm
+simple-parsing

--- a/train.py
+++ b/train.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass
+from simple_parsing import ArgumentParser
+from tqdm.auto import tqdm
+
+import torch as th
+nn = th.nn
+F = nn.functional
+from data_loader import DSRDataset
+from torch.utils.data import DataLoader
+from model import DSRNet
+
+
+@dataclass
+class Config:
+    data_path: str = '/media/ssd/datasets/DSR/real_test_data/'
+    num_frames: int = 10
+    batch_size: int = 2
+    num_epoch: int = 30
+    # Use scene warping layer.
+    use_warp: bool = False
+    # Use action embeddings as inputs.
+    use_action: bool = False
+    device: str = 'cuda'
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_arguments(Config, dest='cfg')
+    cfg = parser.parse_args().cfg
+
+    device = th.device(cfg.device)
+    dataset = DSRDataset(cfg.data_path, 'train', cfg.num_frames)
+    loader = DataLoader(
+        dataset=dataset,
+        batch_size=cfg.batch_size
+    )
+
+    model = DSRNet(cfg.use_warp, cfg.use_action)
+    model = model.to(device)
+
+    optimizer = th.optim.Adam(model.parameters())
+    motion_loss = nn.MSELoss()
+
+    for epoch in tqdm(range(cfg.num_epoch), desc='epoch'):
+        # lr = adjust_learning_rate(...)
+        for data in tqdm(loader, leave=False, desc='batch'):
+            # Formatted as TxBx[...]
+            for i in range(cfg.num_frames):
+                inputs = data[i]
+                outputs = model({k: v.to(device) for k, v in inputs.items()})
+                #inputs['motion'] = inputs['scene_flow_3d']
+                inputs['prv_state'] = outputs['state'].detach()
+                loss = motion_loss(outputs['motion'],
+                                   inputs['scene_flow_3d'].to(device))
+                print(F'loss = {loss.item()}')
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+
+if __name__ == '__main__':
+    main()

--- a/train.py
+++ b/train.py
@@ -47,11 +47,14 @@ def main():
         # lr = adjust_learning_rate(...)
         for data in tqdm(loader, leave=False, desc='batch'):
             # Formatted as TxBx[...]
+            prv_state = None
             for i in range(cfg.num_frames):
                 inputs = data[i]
+                if prv_state is not None:
+                    inputs['prv_state'] = prv_state
                 outputs = model({k: v.to(device) for k, v in inputs.items()})
                 #inputs['motion'] = inputs['scene_flow_3d']
-                inputs['prv_state'] = outputs['state'].detach()
+                prv_state = outputs['state'].detach()
                 loss = motion_loss(outputs['motion'],
                                    inputs['scene_flow_3d'].to(device))
                 print(F'loss = {loss.item()}')


### PR DESCRIPTION
## Description
Implement full DSRNet model & preliminary training pipeline.

### Demo

`train.py` Arguments:
```bash
$ python3 train.py --help
usage: train.py [-h] [--data_path str] [--num_frames int] [--batch_size int] [--num_epoch int] [--use_warp bool] [--use_action bool]
                [--device str]

optional arguments:
  -h, --help         show this help message and exit

Config ['cfg']:
  Config(data_path: str = '/media/ssd/datasets/DSR/real_test_data/', num_frames: int = 10, batch_size: int = 2, num_epoch: int = 30, use_warp: bool = False, use_action: bool = False, device: str = 'cuda')

  --data_path str    (default: /media/ssd/datasets/DSR/real_test_data/)
  --num_frames int   (default: 10)
  --batch_size int   (default: 2)
  --num_epoch int    (default: 30)
  --use_warp bool    Use scene warping layer. (default: False)
  --use_action bool  Use action embeddings as inputs. (default: False)
  --device str       (default: cuda)
```

Run with default args:
```bash
$ python3 train.py 
epoch:   0%|                                                                                                    | 0/30 [00:00<?, ?it/sloss = 0.9745491743087769                                                                                        | 0/25 [00:00<?, ?it/s]
loss = 0.9685857892036438
loss = 0.7516578435897827
loss = 0.4531093239784241
loss = 0.775356650352478
loss = 0.6524146199226379
loss = 1.1313341856002808
```
## Changelog
* Couple of fixes here and there
* Add `DSRNet` full model
* Add `train.py` only training on flow MSE loss