### PR TITLE
Add mask loss

### DIFF
--- a/model.py
+++ b/model.py
@@ -488,7 +488,7 @@ class DSRNet(nn.Module):
         motion = self.motion_predictor(mp_inputs)
 
         outputs: Dict[str, th.Tensor] = {}
-        # outputs['logit'] = logit
+        outputs['logit'] = logit
         outputs['motion'] = motion
         if not self.use_warp:
             outputs['state'] = state

--- a/train.py
+++ b/train.py
@@ -97,11 +97,10 @@ def main():
                 if prv_state is not None:
                     inputs['prv_state'] = prv_state
                 outputs = model({k: v.to(device) for k, v in inputs.items()})
-                #inputs['motion'] = inputs['scene_flow_3d']
                 prv_state = outputs['state'].detach()
                 loss_motion = motion_loss(outputs['motion'],
                                           inputs['scene_flow_3d'].to(device))
-                loss_mask, mask_order = motion_loss(
+                loss_mask, mask_order = mask_loss(
                     outputs['logit'],
                     inputs['mask_3d'].to(device),
                     mask_order)

--- a/train.py
+++ b/train.py
@@ -51,7 +51,7 @@ def mask_loss(
         # CrossEntropyLoss on logits is equivalent to NLL on softmax result
         logit_permuted = th.stack(
             [logit[b:b+1, -1]] + [logit[b:b+1, i] for i in permutation], dim=1)
-        return nn.CrossEntropyLoss()(logit_permuted, mask_gt[b:b + 1])
+        return F.cross_entropy(logit_permuted, mask_gt[b:b + 1])
     loss = 0
     B, K, S1, S2, S3 = logit.size()
     best_mask_order = []

--- a/train.py
+++ b/train.py
@@ -25,6 +25,10 @@ class Config:
     # Use action embeddings as inputs.
     use_action: bool = False
     device: str = 'cuda'
+    # Weight for motion loss
+    loss_motion_weight: float = 1.0
+    # Weight for mask loss
+    loss_mask_weight: float = 5.0
 
 def mask_loss(
     logit: th.Tensor,
@@ -86,6 +90,9 @@ def main():
     optimizer = th.optim.Adam(model.parameters())
     motion_loss = nn.MSELoss()
 
+    loss_motion_weight = cfg.loss_motion_weight
+    loss_mask_weight = cfg.loss_mask_weight
+
     for epoch in tqdm(range(cfg.num_epoch), desc='epoch'):
         # lr = adjust_learning_rate(...)
         for data in tqdm(loader, leave=False, desc='batch'):
@@ -104,7 +111,7 @@ def main():
                     outputs['logit'],
                     inputs['mask_3d'].to(device),
                     mask_order)
-                loss = loss_motion + loss_mask # TODO weight two losses before add
+                loss = loss_motion_weight * loss_motion + loss_mask_weight * loss_mask
                 print(F'loss = {loss.item()}')
                 optimizer.zero_grad()
                 loss.backward()

--- a/train.py
+++ b/train.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 from dataclasses import dataclass
+import itertools
 from simple_parsing import ArgumentParser
 from tqdm.auto import tqdm
+from typing import List, Optional, Tuple
 
 import torch as th
 nn = th.nn
@@ -24,6 +26,47 @@ class Config:
     use_action: bool = False
     device: str = 'cuda'
 
+def mask_loss(
+    logit: th.Tensor,
+    mask_gt: th.Tensor,
+    mask_order: Optional[List[Tuple[int, ...]]] = None
+) -> Tuple[th.Tensor, List[Tuple[int, ...]]]:
+    """
+    Get the mask loss for given mask_order and get the best order for the prediction
+    if mask_order is not given, the best permutation for each batch will be used
+    Arguments:
+        logit: [B, K, S1, S2, S3], the mask predictor output logit(K-1 is none)
+        mask_gt: [B, S1, S2, S3], the ground truth mask index(0 is none)
+        mask_order: mask_order[b] is the permutation tuple of object in batch b(length K-1)
+    """
+    def loss_for_permutation(
+        logit: th.Tensor,
+        mask_gt: th.Tensor,
+        permutation: Tuple[int, ...]
+    ) -> th.Tensor:
+        # CrossEntropyLoss on logits is equivalent to NLL on softmax result
+        logit_permuted = th.stack(
+            [logit[b:b+1, -1]] + [logit[b:b+1, i] for i in permutation], dim=1)
+        return nn.CrossEntropyLoss()(logit_permuted, mask_gt[b:b + 1])
+    loss = 0
+    B, K, S1, S2, S3 = logit.size()
+    best_mask_order = []
+    for b in range(B):
+        best_loss, best_perm = None, None
+        input_permutation = mask_order[b] if mask_order is not None else None
+        for permutation in itertools.permutations(range(K - 1)):
+            cur_loss = loss_for_permutation(logit, mask_gt, permutation)
+            # If mask_order is given, use that
+            if permutation == input_permutation:
+                loss += cur_loss
+            if best_loss is None or cur_loss.item() < best_loss.item():
+                best_loss = cur_loss
+                best_perm = permutation
+        best_mask_order.append(best_perm)
+        # If mask_order is not provided, use the best one
+        if input_permutation is None:
+            loss += best_loss
+    return loss, best_mask_order
 
 def main():
     parser = ArgumentParser()
@@ -48,6 +91,7 @@ def main():
         for data in tqdm(loader, leave=False, desc='batch'):
             # Formatted as TxBx[...]
             prv_state = None
+            mask_order = None
             for i in range(cfg.num_frames):
                 inputs = data[i]
                 if prv_state is not None:
@@ -55,8 +99,13 @@ def main():
                 outputs = model({k: v.to(device) for k, v in inputs.items()})
                 #inputs['motion'] = inputs['scene_flow_3d']
                 prv_state = outputs['state'].detach()
-                loss = motion_loss(outputs['motion'],
-                                   inputs['scene_flow_3d'].to(device))
+                loss_motion = motion_loss(outputs['motion'],
+                                          inputs['scene_flow_3d'].to(device))
+                loss_mask, mask_order = motion_loss(
+                    outputs['logit'],
+                    inputs['mask_3d'].to(device),
+                    mask_order)
+                loss = loss_motion + loss_mask # TODO weight two losses before add
                 print(F'loss = {loss.item()}')
                 optimizer.zero_grad()
                 loss.backward()


### PR DESCRIPTION
### Changes
Adds the mask loss calculation function `mask_loss`, which accepts the mask predictor logit, ground truth label, and optional permutation argument. The function returns both the loss for given mask prediction(which is from previous frame) and the best match(permutation) which will be used in the next frame.
The function is combination of `get_batch_order` and `get_mask_loss`. Actually, I misunderstood the logic for this part in the first time, so I merged two functions. Later I noticed I was wrong, but I decided to not split the function.

`nn.CrossEntropyLoss` was used on logits before softmax instead of NLL on classification results, as in the authors' code, but I can change it to use `clf` and `nn.NLLLoss` if you want.
### TODO
An hyperparameter for multiplying two different losses before adding them should be added, as in the authors' implementation.