### PR TITLE
Enable action encoder and forward warping by default

### DIFF
--- a/forward_warp.py
+++ b/forward_warp.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from cupy import RawKernel
 import numpy as np
 import torch as th
-from torch.autograd.function import Function
+from torch.autograd.function import Function, once_differentiable
 
 Stream = namedtuple('Stream', ['ptr'])
 def get_current_cuda_stream():

--- a/train.py
+++ b/train.py
@@ -24,9 +24,9 @@ class Config:
     batch_size: int = 2
     num_epoch: int = 30
     # Use scene warping layer.
-    use_warp: bool = False
+    use_warp: bool = True
     # Use action embeddings as inputs.
-    use_action: bool = False
+    use_action: bool = True
     device: str = 'cuda'
     # Weight for motion loss
     loss_motion_weight: float = 1.0

--- a/train.py
+++ b/train.py
@@ -161,7 +161,7 @@ def main():
 
     # Add tensorboard graph visualization
     # by converting inputs/outputs to a dummy model.
-    add_tensorboard_graph(model, loader, writer, device)
+    # add_tensorboard_graph(model, loader, writer, device)
     loss_motion_weight = cfg.loss_motion_weight
     loss_mask_weight = cfg.loss_mask_weight
 


### PR DESCRIPTION
Also fixes some errors after enabling them.
The `add_tensorboard_graph` call was commented out because of an error in forward warping layer, due to `torch.tensor.size()`(and `shape` property) returning a tuple of `torch.Tensor`s(instead of `int`s) when running in tracing mode.