### PR TITLE
Support using subsequences in data loader

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -3,15 +3,22 @@ import numpy as np
 from os import PathLike
 from pathlib import Path
 from torch.utils.data import Dataset
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
 
 class DSRDataLoader:
-    def __init__(self, data_path: Union[str, PathLike], split: str, num_frames: int = 10):
+    def __init__(
+        self,
+        data_path: Union[str, PathLike],
+        split: str,
+        num_frames: int = 10,
+        subseq_len: Optional[int] = None
+    ):
         """
         Create DataLoader
         data_path: the path to the dataset(in the format provided by the authors)
         split: 'train' or 'test'
         num_frames: the number of frames for each data(10 for authors')
+        subseq_len: the length of output sequence(equal to num_frames if not given)
         """
         if isinstance(data_path, str):
             data_path = Path(data_path)
@@ -20,18 +27,29 @@ class DSRDataLoader:
 
         self.data_path = data_path
         self.num_frames = num_frames
+        if subseq_len is None:
+            self.subseq_len = num_frames
+            self.num_subseqs_in_seq = 1
+        else:
+            assert num_frames % subseq_len == 0 # subseq_len <= num_frames instead?
+            self.subseq_len = subseq_len
+            self.num_subseqs_in_seq = num_frames // subseq_len
         self.num_directions = 8
         self.volume_size = [128, 128, 48]
         with open(self.data_path / f'{split}.txt', 'r') as f:
             self.idx_list = [line.strip() for line in f.readlines()]
 
     def data_count(self) -> int:
-        return len(self.idx_list)
+        return len(self.idx_list) * self.num_subseqs_in_seq
 
     def load_data(self, index: int) -> List[Dict[str, Any]]:
         frame_list = []
-        data_idx = self.idx_list[index] # convert the index to file index based on the .txt file
-        for frame_idx in range(self.num_frames):
+        # Map index to part of sequence
+        index_video = index // self.num_subseqs_in_seq
+        frame_offset = index % self.num_subseqs_in_seq * self.subseq_len
+        # convert the index to file index based on the .txt file
+        data_idx = self.idx_list[index_video]
+        for frame_idx in range(frame_offset, frame_offset+self.subseq_len):
             filename = f'{data_idx}_{frame_idx}.hdf5'
             frame_data = h5py.File(self.data_path/filename)
             frame_dict = {}
@@ -64,12 +82,18 @@ class DSRDataLoader:
 
 # Helper class for PyTorch Dataset API, which supports automatic batching
 class DSRDataset(Dataset):
-    def __init__(self, data_path: Union[str, PathLike], split: str, num_frames: int = 10):
+    def __init__(
+        self,
+        data_path: Union[str, PathLike],
+        split: str,
+        num_frames: int = 10,
+        subseq_len: Optional[int] = None
+    ):
         super(DSRDataset, self).__init__()
-        self.data_loader = DSRDataLoader(data_path, split, num_frames)
+        self.data_loader = DSRDataLoader(data_path, split, num_frames, subseq_len)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self.data_loader.data_count()
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> List[Dict[str, Any]]:
         return self.data_loader.load_data(index)

--- a/train.py
+++ b/train.py
@@ -20,7 +20,10 @@ from model import DSRNet
 @dataclass
 class Config:
     data_path: str = '/media/ssd/datasets/DSR/real_test_data/'
+    # The number of frames in a sequence
     num_frames: int = 10
+    # The length of subsequences
+    subseq_len: int = 10
     batch_size: int = 2
     num_epoch: int = 30
     # Use scene warping layer.
@@ -146,7 +149,7 @@ def main():
     print(F'Runtime path = {path}')
 
     device = th.device(cfg.device)
-    dataset = DSRDataset(cfg.data_path, 'train', cfg.num_frames)
+    dataset = DSRDataset(cfg.data_path, 'train', cfg.num_frames, cfg.subseq_len)
     loader = DataLoader(
         dataset=dataset,
         batch_size=cfg.batch_size
@@ -169,7 +172,7 @@ def main():
         # Formatted as TxBx[...]
         prv_state = None
         mask_order = None
-        for i in range(cfg.num_frames):
+        for i in range(cfg.subseq_len):
             inputs = data[i]
             if prv_state is not None:
                 inputs['prv_state'] = prv_state
@@ -187,7 +190,7 @@ def main():
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
-        return step + cfg.num_frames
+        return step + cfg.subseq_len
 
     # Optionally load checkpoint.
     if cfg.load_ckpt_file is not None:

--- a/train.py
+++ b/train.py
@@ -152,7 +152,8 @@ def main():
     dataset = DSRDataset(cfg.data_path, 'train', cfg.num_frames, cfg.subseq_len)
     loader = DataLoader(
         dataset=dataset,
-        batch_size=cfg.batch_size
+        batch_size=cfg.batch_size,
+        shuffle=True,
     )
 
     model = DSRNet(cfg.use_warp, cfg.use_action)


### PR DESCRIPTION
This is required to perform single-step training, as documented in section A.3 in the paper.
`num_frames` and `subseq_len` probably require better names, so please let me know if you have any ideas.